### PR TITLE
Guard FieldEffectSystem debug helpers against null collections

### DIFF
--- a/Love-Metro-2D-main/Assets/Scripts/FieldEffects/Core/FieldEffectSystem.cs
+++ b/Love-Metro-2D-main/Assets/Scripts/FieldEffects/Core/FieldEffectSystem.cs
@@ -460,9 +460,15 @@ public class FieldEffectSystem : MonoBehaviour
     
     public int GetTotalEffectsCount()
     {
+        if (_effectsByCategory == null)
+        {
+            return 0;
+        }
+
         int count = 0;
         foreach (var effects in _effectsByCategory.Values)
         {
+            if (effects == null) continue;
             count += effects.Count;
         }
         return count;
@@ -476,8 +482,14 @@ public class FieldEffectSystem : MonoBehaviour
     public List<IFieldEffect> GetActiveEffects()
     {
         var allActiveEffects = new List<IFieldEffect>();
+        if (_effectsByCategory == null)
+        {
+            return allActiveEffects;
+        }
+
         foreach (var effects in _effectsByCategory.Values)
         {
+            if (effects == null) continue;
             allActiveEffects.AddRange(effects);
         }
         return allActiveEffects;
@@ -485,10 +497,16 @@ public class FieldEffectSystem : MonoBehaviour
     
     public void ClearAllEffects()
     {
+        if (_effectsByCategory == null)
+        {
+            return;
+        }
+
         // Создаем копию списка эффектов для безопасного удаления
         var effectsToRemove = new List<IFieldEffect>();
         foreach (var effects in _effectsByCategory.Values)
         {
+            if (effects == null) continue;
             effectsToRemove.AddRange(effects);
         }
         


### PR DESCRIPTION
## Summary
- guard against null `_effectsByCategory` in debug helper methods
- ensure methods skip any null lists

## Testing
- `pytest -q`
- `npm test --silent`
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6862c9b31d608333946e016878bee05d